### PR TITLE
Added Mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Tools that are not tied to a particular platform or language.
 - [Gephi](https://github.com/gephi/gephi) - An open-source platform for visualizing and manipulating large graphs
 - [Kepler.gl](http://kepler.gl/) - Geospatial analysis tool for large-scale data sets.
 - [Lightning](http://lightning-viz.org/) - A data-visualization server providing API-based access to reproducible, web-based, interactive visualizations.
+- [Mermaid](https://github.com/knsv/mermaid) - A tool used to generate diagrams and flowcharts from text in a similar manner as markdown.
 - [RAW](http://rawgraphs.io) - Create web visualizations from CSV or Excel files.
 - [Spark](https://github.com/holman/spark) - Sparklines for the shell. It have several [implementations in different languages](https://github.com/holman/spark/wiki/Alternative-Implementations).
 


### PR DESCRIPTION
A tool used to generate diagrams and flowcharts from text in a similar manner as markdown. This one differs from Mermaidjs by being the 'original' language-agnostic tool.