### PR TITLE
Add ipychart

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ A curated list of awesome **open-source** data visualizations frameworks, librar
 - [ggplot](https://github.com/yhat/ggpy) - plotting system based on [R's](#r-tools) ggplot2.
 - [glumpy](https://github.com/glumpy/glumpy) - OpenGL scientific visualizations library.
 - [holoviews](http://holoviews.org/) - Complex and declarative visualizations from annotated data.
+- [ipychart](https://github.com/nicohlr/ipychart) - The power of Chart.js in Jupyter Notebook.
 - [mayai](http://docs.enthought.com/mayavi/mayavi/) - interactive scientific data visualization and 3D plotting in Python.
 - [matplotlib](http://matplotlib.org/) - 2D plotting library.
 - [missingno](https://github.com/ResidentMario/missingno) - provides flexible toolset of data-visualization utilities that allows quick visual summary of the completeness of your dataset, based on matplotlib.


### PR DESCRIPTION
Add ipychart, a new data visualization library for the Jupyter Notebook environment powered by Chart.js, the famous Javascript library, in the backend.

Official documentation: https://nicohlr.gitlab.io/ipychart/
Github repo: https://github.com/nicohlr/ipychart