### PR TITLE
Fix tests for amazon links

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,4 +20,4 @@ jobs:
     - name: Checks
       run: |
         gem install awesome_bot
-        awesome_bot README.md --allow-redirect 
+        awesome_bot README.md --allow-redirect --allow 503


### PR DESCRIPTION
Looks like sometimes Amazon links return 503, error is safe to ignore.